### PR TITLE
Fix deprecated ShapedRecipe constructor

### DIFF
--- a/src/main/java/powermining/PowerMining.java
+++ b/src/main/java/powermining/PowerMining.java
@@ -75,7 +75,7 @@ public final class PowerMining extends JavaPlugin {
 
 	public void processConfig() {
 		try {
-			for (Object x : (ArrayList<?>) getConfig().getList("Minable")) {
+			for (Object x : getConfig().getList("Minable")) {
 				LinkedHashMap<String, ArrayList> l = (LinkedHashMap<String, ArrayList>)x;
 
 				for (String blockType: l.keySet()) {
@@ -95,8 +95,7 @@ public final class PowerMining extends JavaPlugin {
 						if (hammerType.equals("any"))
 							temp = null;
 
-						if (hammerType != null && (Material.getMaterial(hammerType) == null ||
-								(temp != null && temp.contains(Material.getMaterial(hammerType)))))
+						if (Material.getMaterial(hammerType) == null || temp != null && temp.contains(Material.getMaterial(hammerType)))
 							continue;
 
 						if (temp != null)

--- a/src/main/java/powermining/crafting/CraftItemExcavator.java
+++ b/src/main/java/powermining/crafting/CraftItemExcavator.java
@@ -15,6 +15,7 @@ package powermining.crafting;
 import java.util.ArrayList;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -82,12 +83,12 @@ public class CraftItemExcavator {
 
 	// Creates the ShapedRecipe patterns for all excavator types
 	public void setRecipes() {
-		WoodExcavatorRecipe = new ShapedRecipe(WoodExcavator);
-		StoneExcavatorRecipe = new ShapedRecipe(StoneExcavator);
-		IronExcavatorRecipe = new ShapedRecipe(IronExcavator);
-		GoldExcavatorRecipe = new ShapedRecipe(GoldExcavator);
-		DiamondExcavatorRecipe = new ShapedRecipe(DiamondExcavator);
-		NetheriteExcavatorRecipe = new ShapedRecipe(NetheriteExcavator);
+		WoodExcavatorRecipe = new ShapedRecipe(new NamespacedKey(plugin, "WoodExcavator"), WoodExcavator);
+		StoneExcavatorRecipe = new ShapedRecipe(new NamespacedKey(plugin, "StoneExcavator"), StoneExcavator);
+		IronExcavatorRecipe = new ShapedRecipe(new NamespacedKey(plugin, "IronExcavator"), IronExcavator);
+		GoldExcavatorRecipe = new ShapedRecipe(new NamespacedKey(plugin, "GoldExcavator"), GoldExcavator);
+		DiamondExcavatorRecipe = new ShapedRecipe(new NamespacedKey(plugin, "DiamondExcavator"), DiamondExcavator);
+		NetheriteExcavatorRecipe = new ShapedRecipe(new NamespacedKey(plugin, "NetheriteExcavator"), NetheriteExcavator);
 
 		WoodExcavatorRecipe.shape(" m ", "mim", " m ");
 		WoodExcavatorRecipe.setIngredient('m', Material.LEGACY_LOG);

--- a/src/main/java/powermining/crafting/CraftItemExcavator.java
+++ b/src/main/java/powermining/crafting/CraftItemExcavator.java
@@ -13,6 +13,7 @@
 package powermining.crafting;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -56,15 +57,16 @@ public class CraftItemExcavator {
 		ItemMeta DiamondExcavatorMeta = DiamondExcavator.getItemMeta();
 		ItemMeta NetheriteExcavatorMeta = NetheriteExcavator.getItemMeta();
 
-		ArrayList<String> lore = new ArrayList<String>();
+		ArrayList<String> lore = new ArrayList<>();
 		lore.add(loreString);
 
-		WoodExcavatorMeta.setDisplayName("Wooden Excavator");
-		StoneExcavatorMeta.setDisplayName("Stone Excavator");
-		IronExcavatorMeta.setDisplayName("Iron Excavator");
-		GoldExcavatorMeta.setDisplayName("Golden Excavator");
-		DiamondExcavatorMeta.setDisplayName("Diamond Excavator");
-		NetheriteExcavatorMeta.setDisplayName("Netherite Excavator");
+		// A NullPointerException when one of the metaData's is null is fine, because they shouldn't be null.
+		Objects.requireNonNull(WoodExcavatorMeta).setDisplayName("Wooden Excavator");
+		Objects.requireNonNull(StoneExcavatorMeta).setDisplayName("Stone Excavator");
+		Objects.requireNonNull(IronExcavatorMeta).setDisplayName("Iron Excavator");
+		Objects.requireNonNull(GoldExcavatorMeta).setDisplayName("Golden Excavator");
+		Objects.requireNonNull(DiamondExcavatorMeta).setDisplayName("Diamond Excavator");
+		Objects.requireNonNull(NetheriteExcavatorMeta).setDisplayName("Netherite Excavator");
 
 		WoodExcavatorMeta.setLore(lore);
 		StoneExcavatorMeta.setLore(lore);

--- a/src/main/java/powermining/crafting/CraftItemHammer.java
+++ b/src/main/java/powermining/crafting/CraftItemHammer.java
@@ -15,6 +15,7 @@ package powermining.crafting;
 import java.util.ArrayList;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -82,12 +83,12 @@ public class CraftItemHammer {
 
 	// Creates the ShapedRecipe patterns for all hammer types
 	public void setRecipes() {
-		WoodHammerRecipe = new ShapedRecipe(WoodHammer);
-		StoneHammerRecipe = new ShapedRecipe(StoneHammer);
-		IronHammerRecipe = new ShapedRecipe(IronHammer);
-		GoldHammerRecipe = new ShapedRecipe(GoldHammer);
-		DiamondHammerRecipe = new ShapedRecipe(DiamondHammer);
-		NetheriteHammerRecipe = new ShapedRecipe(NetheriteHammer);
+		WoodHammerRecipe = new ShapedRecipe(new NamespacedKey(plugin, "WoodHammer"), WoodHammer);
+		StoneHammerRecipe = new ShapedRecipe(new NamespacedKey(plugin, "StoneHammer"), StoneHammer);
+		IronHammerRecipe = new ShapedRecipe(new NamespacedKey(plugin, "IronHammer"), IronHammer);
+		GoldHammerRecipe = new ShapedRecipe(new NamespacedKey(plugin, "GoldHammer"), GoldHammer);
+		DiamondHammerRecipe = new ShapedRecipe(new NamespacedKey(plugin, "DiamondHammer"), DiamondHammer);
+		NetheriteHammerRecipe = new ShapedRecipe(new NamespacedKey(plugin, "NetheriteHammer"), NetheriteHammer);
 
 		WoodHammerRecipe.shape(" m ", "mim", " m ");
 		WoodHammerRecipe.setIngredient('m', Material.LEGACY_LOG);

--- a/src/main/java/powermining/crafting/CraftItemHammer.java
+++ b/src/main/java/powermining/crafting/CraftItemHammer.java
@@ -13,6 +13,7 @@
 package powermining.crafting;
 
 import java.util.ArrayList;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -56,15 +57,16 @@ public class CraftItemHammer {
 		ItemMeta DiamondHammerMeta = DiamondHammer.getItemMeta();
 		ItemMeta NetheriteHammerMeta = NetheriteHammer.getItemMeta();
 
-		ArrayList<String> lore = new ArrayList<String>();
+		ArrayList<String> lore = new ArrayList<>();
 		lore.add(loreString);
 
-		WoodHammerMeta.setDisplayName("Wooden Hammer");
-		StoneHammerMeta.setDisplayName("Stone Hammer");
-		IronHammerMeta.setDisplayName("Iron Hammer");
-		GoldHammerMeta.setDisplayName("Golden Hammer");
-		DiamondHammerMeta.setDisplayName("Diamond Hammer");
-		NetheriteHammerMeta.setDisplayName("Netherite Hammer");
+		// A NullPointerException when one of the metaData's is null is fine, because they shouldn't be null.
+		Objects.requireNonNull(WoodHammerMeta).setDisplayName("Wooden Hammer");
+		Objects.requireNonNull(StoneHammerMeta).setDisplayName("Stone Hammer");
+		Objects.requireNonNull(IronHammerMeta).setDisplayName("Iron Hammer");
+		Objects.requireNonNull(GoldHammerMeta).setDisplayName("Golden Hammer");
+		Objects.requireNonNull(DiamondHammerMeta).setDisplayName("Diamond Hammer");
+		Objects.requireNonNull(NetheriteHammerMeta).setDisplayName("Netherite Hammer");
 
 		WoodHammerMeta.setLore(lore);
 		StoneHammerMeta.setLore(lore);

--- a/src/main/java/powermining/handlers/BlockBreakHandler.java
+++ b/src/main/java/powermining/handlers/BlockBreakHandler.java
@@ -16,7 +16,7 @@ import powermining.PowerMining;
 import powermining.listeners.BlockBreakListener;
 
 public class BlockBreakHandler {
-	public BlockBreakHandler() {};
+	public BlockBreakHandler() {}
 	public BlockBreakListener listener;
 
 	public void Init(PowerMining plugin) {

--- a/src/main/java/powermining/handlers/CraftItemHandler.java
+++ b/src/main/java/powermining/handlers/CraftItemHandler.java
@@ -18,7 +18,7 @@ import powermining.crafting.CraftItemHammer;
 import powermining.listeners.CraftItemListener;
 
 public class CraftItemHandler {
-	public CraftItemHandler() {};
+	public CraftItemHandler() {}
 	public CraftItemHammer HammerClass;
 	public CraftItemExcavator ExcavatorClass;
 	public CraftItemListener listener;

--- a/src/main/java/powermining/handlers/EnchantItemHandler.java
+++ b/src/main/java/powermining/handlers/EnchantItemHandler.java
@@ -16,7 +16,7 @@ import powermining.PowerMining;
 import powermining.listeners.EnchantItemListener;
 
 public class EnchantItemHandler {
-	public EnchantItemHandler() {};
+	public EnchantItemHandler() {}
 	public EnchantItemListener listener;
 
 	public void Init(PowerMining plugin) {

--- a/src/main/java/powermining/handlers/InventoryClickHandler.java
+++ b/src/main/java/powermining/handlers/InventoryClickHandler.java
@@ -16,7 +16,7 @@ import powermining.PowerMining;
 import powermining.listeners.InventoryClickListener;
 
 public class InventoryClickHandler {
-	public InventoryClickHandler() {};
+	public InventoryClickHandler() {}
 	public InventoryClickListener listener;
 
 	public void Init(PowerMining plugin) {

--- a/src/main/java/powermining/handlers/PlayerInteractHandler.java
+++ b/src/main/java/powermining/handlers/PlayerInteractHandler.java
@@ -16,7 +16,7 @@ import powermining.PowerMining;
 import powermining.listeners.PlayerInteractListener;
 
 public class PlayerInteractHandler {
-	public PlayerInteractHandler() {};
+	public PlayerInteractHandler() {}
 	public PlayerInteractListener listener;
 
 	public void Init(PowerMining plugin) {

--- a/src/main/java/powermining/lib/PowerUtils.java
+++ b/src/main/java/powermining/lib/PowerUtils.java
@@ -8,10 +8,7 @@
 
 package powermining.lib;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 import powermining.PowerMining;
 import powermining.crafting.CraftItemExcavator;
@@ -36,7 +33,8 @@ public class PowerUtils {
 		if (item == null || !item.hasItemMeta())
 			return false;
 
-		List<String> lore = item.getItemMeta().getLore();
+		// This should not throw a NullPointerException because hasItemMeta is checked above.
+		List<String> lore = Objects.requireNonNull(item.getItemMeta()).getLore();
 
 		if (lore == null)
 			return false;

--- a/src/main/java/powermining/lib/Reference.java
+++ b/src/main/java/powermining/lib/Reference.java
@@ -19,34 +19,34 @@ import java.util.HashMap;
 import org.bukkit.Material;
 
 public class Reference {
-	public static HashMap<Material, ArrayList<Material>> MINABLE = new HashMap<Material, ArrayList<Material>>();
+	public static HashMap<Material, ArrayList<Material>> MINABLE = new HashMap<>();
 
-	public static ArrayList<Material> DIGGABLE = new ArrayList<Material>();
+	public static ArrayList<Material> DIGGABLE = new ArrayList<>();
 
-	public static ArrayList<Material> MINABLE_SILKTOUCH =  new ArrayList<Material>(Arrays.asList(
-		Material.STONE,
-		Material.COAL_ORE,
-		Material.REDSTONE_ORE,
-		Material.LEGACY_GLOWING_REDSTONE_ORE,
-		Material.LAPIS_ORE,
-		Material.DIAMOND_ORE,
-		Material.EMERALD_ORE,
-		Material.ICE,
-		Material.NETHER_QUARTZ_ORE,
-		Material.GLOWSTONE
+	public static ArrayList<Material> MINABLE_SILKTOUCH = new ArrayList<>(Arrays.asList(
+			Material.STONE,
+			Material.COAL_ORE,
+			Material.REDSTONE_ORE,
+			Material.LEGACY_GLOWING_REDSTONE_ORE,
+			Material.LAPIS_ORE,
+			Material.DIAMOND_ORE,
+			Material.EMERALD_ORE,
+			Material.ICE,
+			Material.NETHER_QUARTZ_ORE,
+			Material.GLOWSTONE
 	));
 
-	public static ArrayList<Material> DIGGABLE_SILKTOUCH =  new ArrayList<Material>(Arrays.asList(
-		Material.GRASS,
-		Material.CLAY,
-		Material.SNOW_BLOCK,
-		Material.LEGACY_MYCEL,
-		Material.GLOWSTONE
+	public static ArrayList<Material> DIGGABLE_SILKTOUCH = new ArrayList<>(Arrays.asList(
+			Material.GRASS,
+			Material.CLAY,
+			Material.SNOW_BLOCK,
+			Material.LEGACY_MYCEL,
+			Material.GLOWSTONE
 	));
 
 	public static HashMap<Material, Material> MINABLE_FORTUNE;
 	static {
-		MINABLE_FORTUNE = new HashMap<Material, Material>();
+		MINABLE_FORTUNE = new HashMap<>();
 
 		MINABLE_FORTUNE.put(Material.COAL_ORE, Material.COAL);
 		MINABLE_FORTUNE.put(Material.REDSTONE_ORE, Material.REDSTONE);
@@ -56,31 +56,31 @@ public class Reference {
 		MINABLE_FORTUNE.put(Material.EMERALD_ORE, Material.EMERALD);
 		MINABLE_FORTUNE.put(Material.NETHER_QUARTZ_ORE, Material.QUARTZ);
 		MINABLE_FORTUNE.put(Material.GLOWSTONE, Material.GLOWSTONE_DUST);
-	};
+	}
 
 	public static HashMap<Material, Material> DIGGABLE_FORTUNE;
 	static {
-		DIGGABLE_FORTUNE = new HashMap<Material, Material>();
+		DIGGABLE_FORTUNE = new HashMap<>();
 
 		DIGGABLE_FORTUNE.put(Material.GRAVEL, Material.FLINT);
 		DIGGABLE_FORTUNE.put(Material.GLOWSTONE, Material.GLOWSTONE_DUST);
-	};
+	}
 
-	public static ArrayList<Material> PICKAXES =  new ArrayList<Material>(Arrays.asList(
-		Material.WOODEN_PICKAXE,
-		Material.STONE_PICKAXE,
-		Material.IRON_PICKAXE,
-		Material.GOLDEN_PICKAXE,
-		Material.DIAMOND_PICKAXE,
-		Material.NETHERITE_PICKAXE
+	public static ArrayList<Material> PICKAXES = new ArrayList<>(Arrays.asList(
+			Material.WOODEN_PICKAXE,
+			Material.STONE_PICKAXE,
+			Material.IRON_PICKAXE,
+			Material.GOLDEN_PICKAXE,
+			Material.DIAMOND_PICKAXE,
+			Material.NETHERITE_PICKAXE
 	));
 
-	public static ArrayList<Material> SPADES = new ArrayList<Material>(Arrays.asList(
-		Material.WOODEN_SHOVEL,
-		Material.STONE_SHOVEL,
-		Material.IRON_SHOVEL,
-		Material.GOLDEN_SHOVEL,
-		Material.DIAMOND_SHOVEL,
-		Material.NETHERITE_SHOVEL
+	public static ArrayList<Material> SPADES = new ArrayList<>(Arrays.asList(
+			Material.WOODEN_SHOVEL,
+			Material.STONE_SHOVEL,
+			Material.IRON_SHOVEL,
+			Material.GOLDEN_SHOVEL,
+			Material.DIAMOND_SHOVEL,
+			Material.NETHERITE_SHOVEL
 	));
 }

--- a/src/main/java/powermining/listeners/BlockBreakListener.java
+++ b/src/main/java/powermining/listeners/BlockBreakListener.java
@@ -41,90 +41,88 @@ public class BlockBreakListener implements Listener {
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void checkToolAndBreakBlocks(BlockBreakEvent event) {
 		Player player = event.getPlayer();
-		ItemStack handItem = player.getItemInHand();
+		ItemStack handItem = player.getInventory().getItemInMainHand();
 		Material handItemType = handItem.getType();
 
-		if (player != null && (player instanceof Player)) {
-			// If the player is sneaking, we want the tool to act like a normal pickaxe/shovel
-			if (player.isSneaking())
-				return;
+		// If the player is sneaking, we want the tool to act like a normal pickaxe/shovel
+		if (player.isSneaking())
+			return;
 
-			// If the player does not have permission to use the tool, acts like a normal pickaxe/shovel
-			if (!PowerUtils.checkUsePermission(player, handItemType))
-				return;
+		// If the player does not have permission to use the tool, acts like a normal pickaxe/shovel
+		if (!PowerUtils.checkUsePermission(player, handItemType))
+			return;
 
-			// If this is not a power tool, acts like a normal pickaxe
-			if (!PowerUtils.isPowerTool(handItem))
-				return;
+		// If this is not a power tool, acts like a normal pickaxe
+		if (!PowerUtils.isPowerTool(handItem))
+			return;
 
-			Block block = event.getBlock();
-			String playerName = player.getName();
+		Block block = event.getBlock();
+		String playerName = player.getName();
 
-			PlayerInteractListener pil = plugin.getPlayerInteractHandler().getListener();
-			BlockFace blockFace = pil.getBlockFaceByPlayerName(playerName);
+		PlayerInteractListener pil = plugin.getPlayerInteractHandler().getListener();
+		BlockFace blockFace = pil.getBlockFaceByPlayerName(playerName);
 
-			Map<Enchantment, Integer> enchants = handItem.getEnchantments();
-			Enchantment enchant = null;
-			int enchantLevel = 0;
-			if (enchants.get(Enchantment.SILK_TOUCH) != null) {
-				enchant = Enchantment.SILK_TOUCH;
-				enchantLevel = enchants.get(Enchantment.SILK_TOUCH);
-			}
-			else if (enchants.get(Enchantment.LOOT_BONUS_BLOCKS) != null) {
-				enchant = Enchantment.LOOT_BONUS_BLOCKS;
-				enchantLevel = enchants.get(Enchantment.LOOT_BONUS_BLOCKS);
-			}
+		Map<Enchantment, Integer> enchants = handItem.getEnchantments();
+		Enchantment enchant = null;
+		int enchantLevel = 0;
+		if (enchants.get(Enchantment.SILK_TOUCH) != null) {
+			enchant = Enchantment.SILK_TOUCH;
+			enchantLevel = enchants.get(Enchantment.SILK_TOUCH);
+		}
+		else if (enchants.get(Enchantment.LOOT_BONUS_BLOCKS) != null) {
+			enchant = Enchantment.LOOT_BONUS_BLOCKS;
+			enchantLevel = enchants.get(Enchantment.LOOT_BONUS_BLOCKS);
+		}
 
-			short curDur = handItem.getDurability();
-			short maxDur = handItem.getType().getMaxDurability();
+		short curDur = handItem.getDurability();
+		short maxDur = handItem.getType().getMaxDurability();
 
-			// Breaks surrounding blocks as long as they match the corresponding tool
-			for (Block e: PowerUtils.getSurroundingBlocks(blockFace, block)) {
-				Material blockMat = e.getType();
-				Location blockLoc = e.getLocation();
+		// Breaks surrounding blocks as long as they match the corresponding tool
+		for (Block e: PowerUtils.getSurroundingBlocks(blockFace, block)) {
+			Material blockMat = e.getType();
+			Location blockLoc = e.getLocation();
 
-				boolean useHammer = false;
-				boolean useExcavator = false;
+			boolean useHammer = false;
+			boolean useExcavator = false;
 
-				// This bit is necessary to guarantee we only get one or the other as true, otherwise it might break blocks with the wrong tool
-				if (useHammer = PowerUtils.validateHammer(handItem.getType(), blockMat));
-				else if (useExcavator = PowerUtils.validateExcavator(handItem.getType(), blockMat));
+			// This bit is necessary to guarantee we only get one or the other as true, otherwise it might break blocks with the wrong tool
+			if (useHammer = PowerUtils.validateHammer(handItem.getType(), blockMat));
+			else if (useExcavator = PowerUtils.validateExcavator(handItem.getType(), blockMat));
 
-				if (useHammer || useExcavator) {
+			if (useHammer || useExcavator) {
 
-					// Check if player has permission to break the block
-					if (!PowerUtils.canBreak(plugin, player, e))
-						continue;
+				// Check if player has permission to break the block
+				if (!PowerUtils.canBreak(plugin, player, e))
+					continue;
 
-					// Snowballs do not drop if you just breakNaturally(), so this needs to be special parsed
-					if (blockMat == Material.SNOW && useExcavator) {
-						ItemStack snow = new ItemStack(Material.LEGACY_SNOW_BALL, 1 + e.getData());
-						e.getWorld().dropItemNaturally(blockLoc, snow);
+				// Snowballs do not drop if you just breakNaturally(), so this needs to be special parsed
+				if (blockMat == Material.SNOW && useExcavator) {
+					ItemStack snow = new ItemStack(Material.LEGACY_SNOW_BALL, 1 + e.getData());
+					e.getWorld().dropItemNaturally(blockLoc, snow);
+				}
+
+				// If there is no enchant on the item or the block is not on the effect lists, just break
+				if (enchant == null ||
+						((!PowerUtils.canSilkTouchMine(blockMat) || !PowerUtils.canFortuneMine(blockMat)) && useHammer) ||
+						((!PowerUtils.canFortuneDig(blockMat) || !PowerUtils.canFortuneDig(blockMat)) && useExcavator))
+					e.breakNaturally(handItem);
+				else {
+					ItemStack drop = PowerUtils.processEnchantsAndReturnItemStack(enchant, enchantLevel, e);
+
+					if (drop != null) {
+						e.getWorld().dropItemNaturally(blockLoc, drop);
+						e.setType(Material.AIR);
 					}
-
-					// If there is no enchant on the item or the block is not on the effect lists, just break
-					if (enchant == null ||
-							((!PowerUtils.canSilkTouchMine(blockMat) || !PowerUtils.canFortuneMine(blockMat)) && useHammer) ||
-							((!PowerUtils.canFortuneDig(blockMat) || !PowerUtils.canFortuneDig(blockMat)) && useExcavator))
+					else
 						e.breakNaturally(handItem);
-					else {
-						ItemStack drop = PowerUtils.processEnchantsAndReturnItemStack(enchant, enchantLevel, e);
+				}
 
-						if (drop != null) {
-							e.getWorld().dropItemNaturally(blockLoc, drop);
-							e.setType(Material.AIR);
-						}
-						else
-							e.breakNaturally(handItem);
-					}
-
-					// If this is set, durability will be reduced from the tool for each broken block
-					if (useDurabilityPerBlock || !player.hasPermission("powermining.highdurability")) {
-						if (curDur++ < maxDur)
-							handItem.setDurability(curDur);
-						else
-							break;
-					}
+				// If this is set, durability will be reduced from the tool for each broken block
+				if (useDurabilityPerBlock || !player.hasPermission("powermining.highdurability")) {
+					if (curDur++ < maxDur)
+						handItem.setDurability(curDur);
+					else
+						break;
 				}
 			}
 		}

--- a/src/main/java/powermining/listeners/PlayerInteractListener.java
+++ b/src/main/java/powermining/listeners/PlayerInteractListener.java
@@ -24,7 +24,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 
 public class PlayerInteractListener implements Listener {
 	public PowerMining plugin;
-	private HashMap<String, BlockFace> faces = new HashMap<String, BlockFace>();
+	private HashMap<String, BlockFace> faces = new HashMap<>();
 
 	public PlayerInteractListener(PowerMining plugin) {
 		this.plugin = plugin;
@@ -36,10 +36,8 @@ public class PlayerInteractListener implements Listener {
 		Player player = event.getPlayer();
 		BlockFace bf = event.getBlockFace();
 
-		if (player != null && bf != null) {
-			String name = player.getName();
-			faces.put(name, bf);
-		}
+		String name = player.getName();
+		faces.put(name, bf);
 	}
 
 	public BlockFace getBlockFaceByPlayerName(String name) {


### PR DESCRIPTION
Add a NamespacedKey to the ShapedRecipe constructors.
This fixes the warnings in console on startup.

Fix some of the warnings pointed out by IntelliJ.